### PR TITLE
修复删除 emoji 以及选中粘贴出错

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: text_span_field
 description: Flutter custom text style input box enables you to display different styles of text in textfield, such as topic @ user effect
-version: 2.0.4
+version: 2.0.5
 author: 690717394@qq.com
 homepage: https://github.com/JiangJuHong/FlutterTextSpanField
 


### PR DESCRIPTION
在输入框输入 emoji 和 @ 块内容后，删除 emoji 会导致计算块内容的 range 出错，因为 emoji 的长度大部分为 2
修复选中并粘贴时受影响的 @块内容 range 计算出错